### PR TITLE
Issue warning using warn statement, not print

### DIFF
--- a/stable_whisper.py
+++ b/stable_whisper.py
@@ -846,7 +846,7 @@ def add_whole_word_ts(tokenizer: Tokenizer, segments: Union[List[dict], dict], m
     if isinstance(segments, dict):
         segments = segments['segments']
     if not segments:
-        warnings.warn('No segments found, whole-word timestamps cannot be added.')
+        warnings.warn('No segments found, whole-word timestamps cannot be added.', stacklevel=2)
         return
 
     missing_idx = set(-1 if seg.get('word_timestamps') else i for i, seg in enumerate(segments)) - {-1}

--- a/stable_whisper.py
+++ b/stable_whisper.py
@@ -846,7 +846,7 @@ def add_whole_word_ts(tokenizer: Tokenizer, segments: Union[List[dict], dict], m
     if isinstance(segments, dict):
         segments = segments['segments']
     if not segments:
-        print('No segments found, whole-word timestamps cannot be added.')
+        warnings.warn('No segments found, whole-word timestamps cannot be added.')
         return
 
     missing_idx = set(-1 if seg.get('word_timestamps') else i for i, seg in enumerate(segments)) - {-1}


### PR DESCRIPTION
Hello!

I need to process a large amount of short audios, and some of them might not even contain speech. In that case whisper model produces no segments. As a result 2 checks: (1) in `stabilize_timestamps()` and (2) in `add_whole_word_ts()` - print warning messages `No segments found`. One message is issued using `print()`, the other one uses `warnings.warn()`.

It would be nice to have all warning messages `No segments found` to be issued using `warnings.warn()` function instead of regular `print()` statement. The reason is we can avoid clutter in stdout by simply ignoring these warnings using `warnings.catch_warnings()` context manager or `warnings.filterwarnings()` function.

The check in `stabilize_timestamps()` already uses `warnings.warn()`. We need to make the check in `add_whole_word_ts()` use warnings as well to be able to filter these messages if needed.