### PR TITLE
Update text_output.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     license="MIT",
     packages=['stable_whisper'],
     install_requires=[
-      "whisper @ git+https://github.com/openai/whisper.git"
+      "openai-whisper @ git+https://github.com/openai/whisper.git"
     ],
     include_package_data=False
 )

--- a/stable_whisper/text_output.py
+++ b/stable_whisper/text_output.py
@@ -4,7 +4,7 @@ from typing import List
 from stable_whisper.stabilization import group_word_timestamps, tighten_timestamps, MIN_DUR
 
 __all__ = ['results_to_sentence_srt', 'results_to_word_srt', 'results_to_token_srt',
-           'results_to_sentence_word_ass', 'to_srt', 'results_to_srt', 'save_as_json']
+           'results_to_sentence_word_ass', 'to_srt', 'results_to_srt', 'save_as_json', 'results_to_sentence_json', 'results_to_sentence_csv']
 
 
 def to_srt(lines: List[dict], save_path: str = None, strip=False) -> str:


### PR DESCRIPTION
Added additional abilities to export as a CSV file, as well as Json files for sentences. I'm currently using stable-ts to create a conversational AI dataset, and these additions could be useful if one wants to parse the timestamps/text!

Also, I might be making a separate pull request for the ability to split audio based on the timestamps generated by stable-ts, although thought that could be too far removed from the intent of the original repo.