### PR TITLE
Include numpy as an explicit install requirement.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
     license="MIT",
     packages=['stable_whisper'],
     install_requires=[
+      "numpy",
       "whisper @ git+https://github.com/openai/whisper.git"
     ],
     include_package_data=False


### PR DESCRIPTION
Parsing the package during build fails in a clean virtualenv unless the numpy requirement is explicitly listed.

Here's what I see without it:
```
#10 4.661 Collecting stable-ts==1.0.1
#10 4.692   Downloading stable-ts-1.0.1.tar.gz (22 kB)
#10 4.699   Preparing metadata (setup.py): started
#10 4.778   Preparing metadata (setup.py): finished with status 'error'
#10 4.781   error: subprocess-exited-with-error
#10 4.781
#10 4.781   × python setup.py egg_info did not run successfully.
#10 4.781   │ exit code: 1
#10 4.781   ╰─> [10 lines of output]
#10 4.781       Traceback (most recent call last):
#10 4.781         File "<string>", line 2, in <module>
#10 4.781         File "<pip-setuptools-caller>", line 34, in <module>
#10 4.781         File "/tmp/pip-install-8p7p5vdh/stable-ts_3be22db2421c4dc18b13073f08320312/setup.py", line 2, in <module>
#10 4.781           import stable_whisper
#10 4.781         File "/tmp/pip-install-8p7p5vdh/stable-ts_3be22db2421c4dc18b13073f08320312/stable_whisper/__init__.py", line 1, in <module>
#10 4.781           from .stabilization import *
#10 4.781         File "/tmp/pip-install-8p7p5vdh/stable-ts_3be22db2421c4dc18b13073f08320312/stable_whisper/stabilization.py", line 5, in <module>
#10 4.781           import numpy as np
#10 4.781       ModuleNotFoundError: No module named 'numpy'
#10 4.781       [end of output]
#10 4.781
#10 4.781   note: This error originates from a subprocess, and is likely not a problem with pip.
#10 4.782 error: metadata-generation-failed
#10 4.782
#10 4.782 × Encountered error while generating package metadata.
#10 4.782 ╰─> See above for output.
#10 4.782
#10 4.782 note: This is an issue with the package mentioned above, not pip.
#10 4.782 hint: See above for details.
```