### PR TITLE
Changed script name from stable to stable-ts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "openai-whisper==20230124"
     ],
     entry_points={
-        "console_scripts": ["stable=stable_whisper.whisper_word_level:cli"],
+        "console_scripts": ["stable-ts=stable_whisper.whisper_word_level:cli"],
     },
     include_package_data=False
 )


### PR DESCRIPTION
I'm assuming this is what was supposed to have been? Right now the CLI script is called `stable`, took me a couple hours to figure out where the problem was, since the docs say `stable-ts`.