### PR TITLE
Add shell=True in subprocess call in _load_audio

### DIFF
--- a/stable_whisper/audio.py
+++ b/stable_whisper/audio.py
@@ -19,6 +19,7 @@ def _load_file(file: Union[str, bytes], verbose: bool = False):
             verbosity = ' -q' if verbose is None else (' --progress' if verbose else ' --progress -q')
             p = subprocess.run(
                 f'yt-dlp "{file}" -f ba/w -I 1{verbosity} -o -',
+                shell=True,
                 stdout=subprocess.PIPE
             )
             if len(p.stdout) == 0:


### PR DESCRIPTION
Prevents FileNotFoundError thrown when running subprocess and yt-dlp is present