### PR TITLE
Add tqdm to faster-whisper transcribe

### DIFF
--- a/stable_whisper/whisper_word_level.py
+++ b/stable_whisper/whisper_word_level.py
@@ -740,13 +740,15 @@ def load_faster_whisper(model_size_or_path: str, **model_init_options):
 
         final_segments = []
 
-        for segment in segments:
-            segment = segment._asdict()
-            if (words := segment.get('words')) is not None:
-                segment['words'] = [w._asdict() for w in words]
-            else:
-                del segment['words']
-            final_segments.append(segment)
+        with tqdm(total=round(info.duration), unit='sec', disable=verbose is not False) as tqdm_pbar:
+            for segment in segments:
+                segment = segment._asdict()
+                if (words := segment.get('words')) is not None:
+                    segment['words'] = [w._asdict() for w in words]
+                else:
+                    del segment['words']
+                final_segments.append(segment)
+                tqdm_pbar.update(segment["end"] - segment["start"])
 
         if verbose is not None:
             print(f'Completed transcription with faster-whisper ({model_size_or_path}).')


### PR DESCRIPTION
This simple change adds a `tqdm` progress bar to the `load_faster_whisper()` function just like in the regular transcribe function ([reference](https://github.com/jianfch/stable-ts/blob/4a7e52bef88552c91249ff05c580e84cd5c168de/stable_whisper/whisper_word_level.py#L433)).  
From [this comment](https://github.com/guillaumekln/faster-whisper/issues/80#issuecomment-1484086874), it is possible to iterate over the segments and update the progress bar with the number of seconds that have passed. This pull request adds that.