### PR TITLE
Solved CPU Quantization Specification Error

### DIFF
--- a/stable_whisper/quantization.py
+++ b/stable_whisper/quantization.py
@@ -34,7 +34,8 @@ def ptdq_linear(model: "Whisper"):
     """
     Apply Dynamic Quantization to instance of :class:`whisper.model.Whisper`.
     """
-    model.cpu()
+    model.cpu()    
+    torch.backends.quantized.engine = 'qnnpack'
     replace_modules(model, only_linear=True)
     torch.quantization.quantize_dynamic(model, {nn.Linear}, dtype=torch.qint8, inplace=True)
     setattr(model, 'dq', True)

--- a/stable_whisper/quantization.py
+++ b/stable_whisper/quantization.py
@@ -34,8 +34,16 @@ def ptdq_linear(model: "Whisper"):
     """
     Apply Dynamic Quantization to instance of :class:`whisper.model.Whisper`.
     """
-    model.cpu()    
-    torch.backends.quantized.engine = 'qnnpack'
+    model.cpu()
+
+    supported_engines = torch.backends.quantized.supported_engines
+    print(f"Supported quantized engines: {supported_engines}")
+
+    if 'fbgemm' in supported_engines:
+        torch.backends.quantized.engine = 'fbgemm'
+    else:
+        torch.backends.quantized.engine = 'qnnpack'
+
     replace_modules(model, only_linear=True)
     torch.quantization.quantize_dynamic(model, {nn.Linear}, dtype=torch.qint8, inplace=True)
     setattr(model, 'dq', True)


### PR DESCRIPTION
This pull request addresses the `RuntimeError: Didn't find engine for operation quantized::linear_prepack NoQEngine` issue that occurs when using the Dynamic Quantization (DQ) parameter in the Stable-ts library on ARM environments.

The error is caused by not properly specifying the linear engine for quantization in the code. To fix this, the following lines need to be included:

```python
torch.backends.quantized.engine = 'qnnpack'
qconfig = get_default_qconfig('qnnpack')  # or 'fbgemm'
```

The modification in this pull request introduces a check to detect the available quantized engines using `torch.backends.quantized.supported_engines`. If 'fbgemm' is available, it is set as the quantized engine. Otherwise, 'qnnpack' is used as a fallback option.

This change ensures that the appropriate quantized engine is selected based on availability, preventing the RuntimeError from occurring. Thank you for your attention to this matter.