### PR TITLE
Fix: Ensure verbose Parameter is Passed Correctly When vad=True to Suppress Forced tqdm Progress Bar

### DIFF
--- a/stable_whisper/non_whisper.py
+++ b/stable_whisper/non_whisper.py
@@ -349,7 +349,7 @@ def transcribe_any(
                 vad_onnx=vad_onnx, vad_threshold=vad_threshold,
                 q_levels=q_levels, k_size=k_size,
                 sample_rate=curr_audio_sr(True), min_word_dur=min_word_dur,
-                word_level=suppress_word_ts, verbose=True,
+                word_level=suppress_word_ts, verbose=verbose,
                 nonspeech_error=nonspeech_error,
                 use_word_position=use_word_position,
                 min_silence_dur=min_silence_dur

--- a/stable_whisper/non_whisper.py
+++ b/stable_whisper/non_whisper.py
@@ -349,7 +349,7 @@ def transcribe_any(
                 vad_onnx=vad_onnx, vad_threshold=vad_threshold,
                 q_levels=q_levels, k_size=k_size,
                 sample_rate=curr_audio_sr(True), min_word_dur=min_word_dur,
-                word_level=suppress_word_ts, verbose=verbose,
+                word_level=suppress_word_ts, verbose=verbose is not None,
                 nonspeech_error=nonspeech_error,
                 use_word_position=use_word_position,
                 min_silence_dur=min_silence_dur


### PR DESCRIPTION
When vad=True, the verbose parameter is not passed correctly, causing the tqdm Progress Bar to be forcibly displayed even when verbose=None.
By implementing this fix, the verbose parameter will be correctly passed through, providing the expected control over the display of progress bars when using the vad option.

# How to reproduce
```
import stable_whisper

model = stable_whisper.load_faster_whisper('base')
model.transcribe_stable('test.wav', vad=True, verbose=None)
```

# Before Fix
The following unwanted progress bar displays occur:

```
VAD: 100%|█████████████████████████████████| 4.76/4.76 [00:00<00:00, 12.68sec/s]
Adjustment: 100%|███████████████████████| 4.38/4.38 [00:00<00:00, 13197.59sec/s]
```

# After Fix
The progress bar will no longer be forcibly displayed when verbose=None.