### PR TITLE
Fix: Correct command parsing to solve File name too long & FileNotFound

### DIFF
--- a/stable_whisper/video_output.py
+++ b/stable_whisper/video_output.py
@@ -1,4 +1,5 @@
 import os
+import shlex
 import subprocess as sp
 import warnings
 from typing import List
@@ -98,6 +99,7 @@ def encode_video_comparison(
         output_videopath = f'{name}_sub_comparison.mp4'
     cmd = (f'ffmpeg {ow} {background} {border} {audio} '
            f'-filter_complex "{final_fil}"{vc}{ac} -shortest "{output_videopath}"')
+    cmd = shlex.split(cmd)
     if only_cmd:
         return cmd
     if verbose:


### PR DESCRIPTION
Fix command parsing issues by using `shlex.split` to properly handle command parsing

## Description of the Issue
1. When both the `audio file` and the `srt files` are under the same directory as the stable_whisper.encode_video_comparison script is executed, `[Errno 63] File name too long` error occurs on **macOS**. 

2. When both the `audio file` and the `srt files` are **not** under the same directory as the stable_whisper.encode_video_comparison script is executed, `FileNotFound` error occurs due to incorrect command parsing

## Reproduce 
https://github.com/shaishaicookie/stable-ts/tree/reproduce-error-encode_video_comparison/reproduce_error

When running python `reproduce_error.py`, the following error occurs:

```
ffmpeg -n -f lavfi -i color=size=720x90:rate=25:color=black -f lavfi -i color=size=720x3:rate=25:color=white -i "audio.mp3" -filter_complex "[0]drawtext=text='FileNameTooLong':fontcolor=white:fontsize=14:x=10:y=10[a0],[a0]subtitles='audio.srt':force_style='Fontsize=70'[b0],[0]drawtext=text='FileNameTooLong':fontcolor=white:fontsize=14:x=10:y=10[a1],[a1]subtitles='audio.srt':force_style='Fontsize=70'[b1];[b0][1][b1]vstack=inputs=3" -shortest "FileNameTooLong.mp4"
**** An error occurred ****
**** When input files are under same dir as this script ****
[Errno 63] File name too long: 'ffmpeg -n -f lavfi -i color=size=720x90:rate=25:color=black -f lavfi -i color=size=720x3:rate=25:color=white -i "audio.mp3" -filter_complex "[0]drawtext=text=\'FileNameTooLong\':fontcolor=white:fontsize=14:x=10:y=10[a0],[a0]subtitles=\'audio.srt\':force_style=\'Fontsize=70\'[b0],[0]drawtext=text=\'FileNameTooLong\':fontcolor=white:fontsize=14:x=10:y=10[a1],[a1]subtitles=\'audio.srt\':force_style=\'Fontsize=70\'[b1];[b0][1][b1]vstack=inputs=3" -shortest "FileNameTooLong.mp4"'



ffmpeg -n -f lavfi -i color=size=720x90:rate=25:color=black -f lavfi -i color=size=720x3:rate=25:color=white -i "audio/audio.mp3" -filter_complex "[0]drawtext=text='FileNotFoundError':fontcolor=white:fontsize=14:x=10:y=10[a0],[a0]subtitles='audio/audio.srt':force_style='Fontsize=70'[b0],[0]drawtext=text='FileNameTooLong':fontcolor=white:fontsize=14:x=10:y=10[a1],[a1]subtitles='audio/audio.srt':force_style='Fontsize=70'[b1];[b0][1][b1]vstack=inputs=3" -shortest "FileNotFoundError.mp4"
**** An error occurred ****
**** When input files are not under same dir as this script ****
[Errno 2] No such file or directory: 'ffmpeg -n -f lavfi -i color=size=720x90:rate=25:color=black -f lavfi -i color=size=720x3:rate=25:color=white -i "audio/audio.mp3" -filter_complex "[0]drawtext=text=\'FileNotFoundError\':fontcolor=white:fontsize=14:x=10:y=10[a0],[a0]subtitles=\'audio/audio.srt\':force_style=\'Fontsize=70\'[b0],[0]drawtext=text=\'FileNameTooLong\':fontcolor=white:fontsize=14:x=10:y=10[a1],[a1]subtitles=\'audio/audio.srt\':force_style=\'Fontsize=70\'[b1];[b0][1][b1]vstack=inputs=3" -shortest "FileNotFoundError.mp4"'
```