### PR TITLE
Update Whisper and lock HF Transformers version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - backward
   pull_request:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - backward
   pull_request:
     branches:
       - main

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
       - run: python test/test_transcribe.py load_faster_whisper
       - run: python test/test_align.py load_faster_whisper
       - run: python test/test_refine.py load_faster_whisper
-      - run: pip3 install .["hf"] 'transformers<=4.46.3'
+      - run: pip3 install .["hf"]
       - run: python test/test_transcribe.py load_hf_whisper
       - run: python test/test_align.py load_hf_whisper
       - run: python test/test_refine.py load_hf_whisper

--- a/setup.py
+++ b/setup.py
@@ -28,14 +28,14 @@ setup(
         "torch",
         "torchaudio",
         "tqdm",
-        "openai-whisper>=20230314,<=20240930"
+        "openai-whisper>=20230314,<=20250625"
     ],
     extras_require={
         "fw": [
             "faster-whisper"
         ],
         "hf": [
-            "transformers>=4.23.0,<4.49",
+            "transformers>=4.23.0,<=4.46.3",
             "optimum",
             "accelerate"
         ],

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
             "faster-whisper"
         ],
         "hf": [
-            "transformers>=4.23.0",
+            "transformers>=4.23.0,<4.49",
             "optimum",
             "accelerate"
         ],

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
             "faster-whisper"
         ],
         "hf": [
-            "transformers>=4.23.0,<=4.46.3",
+            "transformers>=4.23.0,<=4.47.1",
             "optimum",
             "accelerate"
         ],

--- a/stable_whisper/whisper_compatibility.py
+++ b/stable_whisper/whisper_compatibility.py
@@ -16,6 +16,7 @@ _COMPATIBLE_WHISPER_VERSIONS = (
     '20231117',
     '20240927',
     '20240930',
+    '20250625',
 )
 _required_whisper_ver = _COMPATIBLE_WHISPER_VERSIONS[-1]
 


### PR DESCRIPTION
- Added new Whisper 20250625. (Tests passing)
- Locked HF transformers to <=4.47.1. Higher versions had broken language detection support.